### PR TITLE
Update Go version to 1.21

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        go-version: [ '1.19' ]
+        go-version: [ '1.19', '1.21' ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ go install golang.org/x/lint/golint@latest
 
 ## License
 
-Copyright (c) 2022 Michał Adamczyk.
+Copyright (c) 2023 Michał Adamczyk.
 
 This project is licensed under the [GNU GPL 3 license](https://opensource.org/licenses/GPL-3.0).
 See [LICENSE](LICENSE) for more details.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/mdm-code/gsnip
 
-go 1.19
+go 1.21
 
 require github.com/mdm-code/xdg v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mdm-code/gsnip
 
 go 1.21
 
-require github.com/mdm-code/xdg v1.0.0
+require github.com/mdm-code/xdg v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/mdm-code/xdg v1.0.0 h1:3uvHRQKAMZyvcdXqPaECKDfjMxU55coNxTTeMEKUEyg=
-github.com/mdm-code/xdg v1.0.0/go.mod h1:wsuj6k3Tjj56WGsX11rHDI7AXyl7DnXJtJvGJ7e8ZvM=
+github.com/mdm-code/xdg v1.0.1 h1:qa1FCtAbpUmUrOYKVElh65BjaDf7kvuAUoH8cL/1vpQ=
+github.com/mdm-code/xdg v1.0.1/go.mod h1:wXqCih7DF+JZ9Qo8QxGuSYqkxROYSPPHGXJJPjwWHUc=


### PR DESCRIPTION
Update Go version.
Update license date in the README file.
Update versions of dependencies.