### PR TITLE
Fix codecov upload in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,5 +34,8 @@ jobs:
     - name: Test
       run: go test -v -coverprofile coverage.txt -covermode atomic ./...
 
-    - name: Coverage
-      uses: codecov/codecov-action@v2.1.0
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        go-version: [ '1.19', '1.21' ]
+        go-version: [ '1.21' ]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
- Removed Go version 1.19 from CI matrix
- Fixed codecov upload action in CI
